### PR TITLE
fix: SQL syntax errors and retrieve latest comments logic

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -314,7 +314,7 @@ SELECT * FROM comment
 WHERE
   (?1 OR url = ?2) AND
   NOT isSpam AND
-  (?3 OR rid = "") AND
+  (?3 OR rid = "")
 LIMIT ?4
 `.trim()))
   }
@@ -1056,31 +1056,38 @@ async function getRecentComments (event) {
   const res = {}
   try {
     if (event.pageSize > 100) event.pageSize = 100
-    let result
-    if (event.urls && event.urls.length) {
-      result = await db.recentCommentsByUrlQuery.bind(
-        1, '', event.includeReply, event.pageSize || 10
-      ).all()
-    } else {
-      result = (await Promise.all(event.urls.map(
-        (url) => db.recentCommentsByUrlQuery.bind(
-          0, url, event.includeReply, event.pageSize || 10
-        ).all()
-      ))).flat()
-    }
-    res.data = result.map((comment) => {
-      return {
-        id: comment._id.toString(),
-        url: comment.url,
-        nick: comment.nick,
-        avatar: getAvatar(comment, config),
-        mailMd5: getMailMd5(comment),
-        link: comment.link,
-        comment: comment.comment,
-        commentText: $(comment.comment).text(),
-        created: comment.created
+
+    const queryComments = (urls) => {
+      const pageSize = event.pageSize || 10;
+      const { includeReply } = event;
+
+      if (urls?.length) {
+        return Promise.all(urls.map(
+					(url) => db.recentCommentsByUrlQuery.bind(0, url, includeReply, pageSize).all()
+        )).then(results => results.flat());
       }
-    })
+
+      return db.recentCommentsByUrlQuery.bind(1, '', includeReply, pageSize).all();
+    };
+
+    const formatComment = (comment) => ({
+      id: comment._id.toString(),
+      url: comment.url,
+      nick: comment.nick,
+      avatar: getAvatar(comment, config),
+      mailMd5: getMailMd5(comment),
+      link: comment.link,
+      comment: comment.comment,
+      commentText: $(comment.comment).text(),
+      created: comment.created
+    });
+
+    const result = await queryComments(event?.urls);
+
+    res.data = (Array.isArray(result)
+      ? result.map(item => item.results?.map(comment => formatComment(comment))).flat()
+      : result.results?.map(comment => formatComment(comment)) || []
+    ).filter(Boolean);
   } catch (e) {
     res.message = e.message
     return res


### PR DESCRIPTION
我发现自己怎么调接口都获取不到最新评论列表，原来是有 BUG

## Summary by Sourcery

修复评论获取的 SQL 和“最近评论”API，以正确返回最新评论，并重构其查询与格式化逻辑。

Bug 修复：
- 修正“最近评论”查询中的 SQL 条件，避免导致无法返回结果的语法错误。
- 修复获取最近评论的逻辑，确保正确处理 URL，并让 API 实际返回最新的评论。

增强功能：
- 将“最近评论”的获取重构为用于查询和结果格式化的辅助函数，包括对多个 URL 的支持以及统一的分页处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix comment retrieval SQL and recent comments API to correctly return latest comments and refactor its querying and formatting logic.

Bug Fixes:
- Correct the SQL condition in the recent comments query to avoid a syntax error that prevented results from being returned.
- Fix the logic for retrieving recent comments so that URLs are handled correctly and the API actually returns the latest comments.

Enhancements:
- Refactor recent comments retrieval into helper functions for querying and formatting results, including support for multiple URLs and unified pagination handling.

</details>