### PR TITLE
fix: Fix SQL syntax errors and retrieve latest comments logic

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -314,7 +314,7 @@ SELECT * FROM comment
 WHERE
   (?1 OR url = ?2) AND
   NOT isSpam AND
-  (?3 OR rid = "") AND
+  (?3 OR rid = "")
 LIMIT ?4
 `.trim()))
   }
@@ -1055,32 +1055,37 @@ async function getCommentsCount (event) {
 async function getRecentComments (event) {
   const res = {}
   try {
-    if (event.pageSize > 100) event.pageSize = 100
-    let result
-    if (event.urls && event.urls.length) {
-      result = await db.recentCommentsByUrlQuery.bind(
-        1, '', event.includeReply, event.pageSize || 10
-      ).all()
-    } else {
-      result = (await Promise.all(event.urls.map(
-        (url) => db.recentCommentsByUrlQuery.bind(
-          0, url, event.includeReply, event.pageSize || 10
-        ).all()
-      ))).flat()
-    }
-    res.data = result.map((comment) => {
-      return {
-        id: comment._id.toString(),
-        url: comment.url,
-        nick: comment.nick,
-        avatar: getAvatar(comment, config),
-        mailMd5: getMailMd5(comment),
-        link: comment.link,
-        comment: comment.comment,
-        commentText: $(comment.comment).text(),
-        created: comment.created
+    const queryComments = (urls) => {
+      const pageSize = event.pageSize > 100 ? 100 : (event.pageSize || 10)
+      const { includeReply } = event
+
+      if (urls?.length) {
+        return Promise.all(urls.map(
+          (url) => db.recentCommentsByUrlQuery.bind(0, url, includeReply, pageSize).all()
+        )).then(results => results.flat())
       }
+
+      return db.recentCommentsByUrlQuery.bind(1, '', includeReply, pageSize).all()
+    }
+
+    const formatComment = (comment) => ({
+      id: comment._id.toString(),
+      url: comment.url,
+      nick: comment.nick,
+      avatar: getAvatar(comment, config),
+      mailMd5: getMailMd5(comment),
+      link: comment.link,
+      comment: comment.comment,
+      commentText: $(comment.comment).text(),
+      created: comment.created
     })
+
+    const result = await queryComments(event?.urls)
+
+    res.data = (Array.isArray(result)
+      ? result.map(item => item.results?.map(comment => formatComment(comment))).flat()
+      : result.results?.map(comment => formatComment(comment)) || []
+    ).filter(Boolean);
   } catch (e) {
     res.message = e.message
     return res


### PR DESCRIPTION
我发现自己怎么调接口都获取不到最新评论列表，原来是有 BUG

## Summary by Sourcery

修复最新评论获取逻辑，并纠正用于获取评论的 SQL 查询语法。

Bug 修复：
- 通过移除 `LIMIT` 子句前无效的尾部条件，修正 SQL 查询语法。
- 修复最新评论获取逻辑，使其能够正确处理可选的 URL 过滤条件和空的 URL 列表，并按预期返回最新评论。

改进：
- 重构最新评论逻辑，将其提取为可复用的辅助方法，用于查询和格式化结果，同时强制设置最大分页大小为 100。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix recent comments retrieval and correct SQL query syntax for comment fetching.

Bug Fixes:
- Correct SQL query syntax by removing an invalid trailing condition before the LIMIT clause.
- Fix recent comments retrieval so it correctly handles optional URL filters and empty URL lists, returning the latest comments as expected.

Enhancements:
- Refactor recent comments logic into reusable helpers for querying and formatting results while enforcing a maximum page size of 100.

</details>